### PR TITLE
pytest-bdd 7.0.0 (ursaverance effort)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+    - https://staging.continuum.io/prefect/fs/parse-feedstock/pr2/ae16b95
+    - https://staging.continuum.io/prefect/fs/parse_type-feedstock/pr2/eaa4d46

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,41 @@
 {% set name = "pytest-bdd" %}
-{% set version = "3.2.1" %}
+{% set version = "7.0.0" %}
 
 package:
-  name: '{{ name|lower }}'
-  version: '{{ version }}'
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 17e73d2fe119de15bfc7fc1fe639fa4df9ab931e5aa552435fdddcf100c97ec5
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: cb11e33b4419bd281cd6f74027c0b1eedeaf8f8d187edc897b4a61ae976ef9f1
 
 build:
-  noarch: python
   number: 0
+  skip: true  # [py<38]
   entry_points:
     - pytest-bdd = pytest_bdd.scripts:main
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
+    - poetry-core >=1.0.0
   run:
     - python
-    - pip
-    - glob2
     - mako
     - parse
     - parse_type
-    - py
-    - pytest >=3.0.0
-    - six >=1.9.0
+    - pytest >=6.2.0
+    - typing-extensions
 
 test:
   imports:
     - pytest_bdd
+  requires:
+    - pip
   commands:
+    - pip check
     - pytest-bdd --help
 
 about:
@@ -43,10 +44,14 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: BDD for pytest
-  description: "pytest-bdd implements a subset of the Gherkin language to enable automating project requirements testing and to facilitate behavioral driven development."
-  dev_url: 'https://github.com/pytest-dev/pytest-bdd'
-  doc_url: 'https://github.com/pytest-dev/pytest-bdd'
+  description: pytest-bdd implements a subset of the Gherkin language to enable automating project requirements testing and to facilitate behavioral driven development.
+  dev_url: https://github.com/pytest-dev/pytest-bdd
+  doc_url: https://pytest-bdd.readthedocs.io
 
 extra:
-  recipe-maintainers: 
+  recipe-maintainers:
+    - m0nonoke
+    - PertuyF
     - breathe
+  skip-lints:
+    - missing_wheel


### PR DESCRIPTION
[PKG-2697] pytest-bdd 7.0.0

dev url: https://github.com/pytest-dev/pytest-bdd/tree/7.0.0
conda-forge: https://github.com/conda-forge/pytest-bdd-feedstock/blob/main/recipe/meta.yaml
dependencies: https://github.com/pytest-dev/pytest-bdd/blob/7.0.0/pyproject.toml


**Changes:**
- fix recipe, linter's warnings
- update to `7.0.0`
- skip lint missing_wheel

**Depends on**
- AnacondaRecipes/parse_type-feedstock#2
- AnacondaRecipes/parse-feedstock#2


[PKG-2697]: https://anaconda.atlassian.net/browse/PKG-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ